### PR TITLE
scripts/image: set PATH to use bins from build env

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -330,6 +330,7 @@ fi
         echo "mkimage: see scripts/image and scripts/mkimage-odroid if you dont trust"
         # variables used in image script must be passed
         sudo env \
+          PATH="$PATH:/sbin" \
           ROOT="$ROOT" \
           RELEASE_DIR="$RELEASE_DIR" \
           INSTALL="$INSTALL" \


### PR DESCRIPTION
Otherwise binaries from the host system may get called which may react differently, respectively some commands can not be found (like mkfs.vfat in my case) if they are not present on the host.